### PR TITLE
Add quoting to file argument in client command

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -130,7 +130,7 @@
 (defun wakatime-client-command (savep)
   "Return client command executable and arguments.
    Set SAVEP to non-nil for write action."
-  (format "%s %s --file %s %s --plugin %s/%s --key %s --time %.2f"
+  (format "%s %s --file \"%s\" %s --plugin %s/%s --key %s --time %.2f"
     wakatime-python-bin
     wakatime-cli-path
     (buffer-file-name (current-buffer))


### PR DESCRIPTION
to allow logging of paths containing spaces