### PR TITLE
Add "Code" block

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -31,6 +31,8 @@
 ;; `wakatime-cli-path' to the absolute path of the CLI script
 ;; (wakatime-cli.py).
 
+;;; Code:
+
 (defconst wakatime-version "1.0.2")
 (defconst wakatime-user-agent "emacs-wakatime")
 (setq wakatime-noprompt nil)


### PR DESCRIPTION
Without a "Code" block after the "Commentary" block, Melpa puts the entire file into the description for the wakatime-mode page: http://melpa.org/#/wakatime-mode

See https://github.com/samertm/go-stacktracer.el/blob/master/go-stacktracer.el#L67 / http://melpa.org/#/go-stacktracer