### PR TITLE
Use "defvar" instead of "setq" for global variables

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -35,9 +35,9 @@
 
 (defconst wakatime-version "1.0.2")
 (defconst wakatime-user-agent "emacs-wakatime")
-(setq wakatime-noprompt nil)
-(setq wakatime-init-started nil)
-(setq wakatime-init-finished nil)
+(defvar wakatime-noprompt nil)
+(defvar wakatime-init-started nil)
+(defvar wakatime-init-finished nil)
 
 (defgroup wakatime nil
   "Customizations for WakaTime"


### PR DESCRIPTION
Fix the following byte-compile warnings.

```
In toplevel form:
wakatime-mode.el:38:7:Warning: assignment to free variable `wakatime-noprompt'
wakatime-mode.el:39:7:Warning: assignment to free variable
    `wakatime-init-started'
wakatime-mode.el:40:7:Warning: assignment to free variable
    `wakatime-init-finished'
...
```