### PR TITLE
Fix for #23

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -188,12 +188,12 @@
              )
              (when (= 102 exit-status)
                ; If we are retrying already, error out
-               (if retrying
+               (if ,retrying
                    (error "WakaTime Error (%s)" exit-status)
                  ; otherwise, ask for an API key and call ourselves
                  ; recursively
                  (wakatime-prompt-api-key)
-                 (wakatime-call savep t)
+                 (wakatime-call ,savep t)
                )
              )
            )


### PR DESCRIPTION
The closure from the original solution wasn’t really helping. The required function parameters are now referenced by value.