### PR TITLE
Hotfix/api key prompt

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -185,19 +185,19 @@
            (kill-buffer (process-buffer process))
            (let ((exit-status (process-exit-status process)))
              ; first check for config and api-key error
-             (when (or (= 103 exit-status) (= 104 exit-status))
-               ; If we are retrying already, error out
+             (cond
+              ((or (= 103 exit-status) (= 104 exit-status))
                (if ,retrying
                    (error "WakaTime Error (%s)" exit-status)
                  ; otherwise, ask for an API key and call ourselves
                  ; recursively
                  (wakatime-prompt-api-key)
                  (wakatime-call ,savep t)
-               )
-             )
-             ; finally throw unexpected errors
-             (when (not (= 0 exit-status))
+                 )
+              )
+              ((not (= 0 exit-status))
                (error "WakaTime Error (%s)" exit-status)
+              )
              )
            )
          )


### PR DESCRIPTION
the order of exit-code checks did not work anymore (every 103 and 104 is `not 0` and `not 102`). And even with the prompt for the api key it was not being used.
