### PR TITLE
Correctly match cli.py in wakatime-cli-path

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -100,7 +100,7 @@
     (when (s-blank wakatime-cli-path)
       (wakatime-prompt-cli-path))
     (when (not (s-blank wakatime-cli-path))
-      (if (not (string-match-p "\\.cli\\.py$" wakatime-cli-path))
+      (if (not (string-match-p "cli\\.py$" wakatime-cli-path))
         (customize-set-variable 'wakatime-python-bin nil)
         (when (s-blank wakatime-python-bin)
           (wakatime-prompt-python-bin))))


### PR DESCRIPTION
I'm not sure if this is the right fix for #29..., but the code there now is certainly wrong.