### PR TITLE
add defcustom for wakatime to turn itself off on subprocess errors

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -60,6 +60,13 @@
   :type 'string
   :group 'wakatime)
 
+(defcustom wakatime-disable-on-error nil
+  "Turn off wakatime-mode and wakatime-global-mode when errors in
+the wakatime subprocess occurs."
+  :type 'boolean
+  :group 'wakatime)
+
+
 (defun wakatime-debug (msg)
   "Write a string to the *messages* buffer."
   (message "%s" msg))
@@ -195,6 +202,9 @@
            (kill-buffer (process-buffer process))
            (let ((exit-status (process-exit-status process)))
              (when (and (not (= 0 exit-status)) (not (= 102 exit-status)))
+               (when wakatime-disable-on-error
+                 (wakatime-mode -1)
+                 (global-wakatime-mode -1))
                (cond
                  ((= exit-status 103) (error "WakaTime Error (%s) Config file parse error. Check your ~/.wakatime.cfg file." exit-status))
                  ((= exit-status 104) (error "WakaTime Error (%s) Invalid API Key. Set your api key with: (custom-set-variables '(wakatime-api-key \"XXXX\"))" exit-status))


### PR DESCRIPTION
It's always tedious every time there are problems with wakatime I manually have to edit it out of my emacs init to make it stop spewing errors everywhere because disabling the global mode leaves it running in all buffers where its already enabled..

This off by default feature just disables wakatime directly on subprocess errors. It just disables the mode in the current buffer and the global mode so it will continue to disable itself in other buffers if it's enabled there when it fails.