### PR TITLE
Security: Sanitize filename passed to wakatime shell command

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -169,10 +169,10 @@ the wakatime subprocess occurs."
 (defun wakatime-client-command (savep)
   "Return client command executable and arguments.
    Set SAVEP to non-nil for write action."
-  (format "%s%s--file \"%s\" --plugin \"%s/%s\" --time %.2f%s%s"
+  (format "%s%s--file %s --plugin \"%s/%s\" --time %.2f%s%s"
     (if (s-blank wakatime-python-bin) "" (format "\"%s\" " wakatime-python-bin))
     (if (s-blank wakatime-cli-path) "wakatime " (format "\"%s\" " wakatime-cli-path))
-    (buffer-file-name (current-buffer))
+    (shell-quote-argument (buffer-file-name (current-buffer)))
     wakatime-user-agent
     wakatime-version
     (float-time)


### PR DESCRIPTION
This prevents executing arbitary shell commands by using malicious
crafted filenames like '";touch hello.txt;"'