### PR TITLE
Customize the ignored exit codes of wakatime-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ To be sure heartbeats are getting sent, turn on debug mode by adding this line t
 Then run `tail -f ~/.wakatime.log` and make sure you see a 201 response code from the [WakaTime API](https://wakatime.com/api).
 
 [doom install]: https://medium.com/@el.gamerph/how-to-install-wakatime-in-doom-emacs-e5c582e15261
+
+If you want to disable an error message on a particular error code from wakatime-cli, you can set `wakatime-ignore-exit-codes`.

--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -66,6 +66,10 @@ the wakatime subprocess occurs."
   :type 'boolean
   :group 'wakatime)
 
+(defcustom wakatime-ignore-exit-codes '(0 102)
+  "Do not notify users about errors on these CLI exit codes."
+  :type '(repeat integer)
+  :group 'wakatime)
 
 (defun wakatime-debug (msg)
   "Write a string to the *messages* buffer."
@@ -201,7 +205,7 @@ the wakatime subprocess occurs."
          (when (memq (process-status process) '(exit signal))
            (kill-buffer (process-buffer process))
            (let ((exit-status (process-exit-status process)))
-             (when (and (not (= 0 exit-status)) (not (= 102 exit-status)))
+             (unless (member exit-status wakatime-ignore-exit-codes)
                (when wakatime-disable-on-error
                  (wakatime-mode -1)
                  (global-wakatime-mode -1))


### PR DESCRIPTION
I have a problem with the latest wakatime-cli (https://github.com/wakatime/wakatime-cli/issues/509). Emacs lags for half a second whenever `error` is called from the process sentinel, that is when CLI returns an error. By default, the package ignores 0 & 102 and calls `error` on any other code.

However, it seems like the CLI returns 1 when offline or when the server load is high, so Emacs basically becomes unusable, as it lags on every CLI call. So I added a variable to customize the ignored exit codes like this:
```lisp
(setq wakatime-ignore-exit-codes '(0 1 102))
```

