### PR TITLE
Use new Go wakatime-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@
 
 ## Installation
 
-Heads Up! WakaTime depends on [Python](http://www.python.org/getit/) being installed to work correctly.
-
 1. Install wakatime-mode for Emacs using [MELPA](https://melpa.org/#/wakatime-mode) (Doom users see [these instructions][doom install] instead).
 
-2. Install [wakatime-cli](https://pypi.python.org/pypi/wakatime) with `pip install wakatime`.
+2. Download [wakatime-cli](https://github.com/wakatime/wakatime-cli/releases) to `~/.wakatime/` or somewhere in your `$PATH`. (Or `brew install wakatime-cli` on Mac)
 
 3. Add `(global-wakatime-mode)` to your `init.el` file, then restart Emacs.
 
-4. You will see a prompt asking for the path to wakatime-cli. Run `which wakatime` and enter that path into the emacs prompt, then press `enter`.
+4. You will see a prompt asking for the path to wakatime-cli. Run `which wakatime-cli` and enter that path into the emacs prompt, then press `enter`.
 
-5. Enter your [api key](https://wakatime.com/settings#apikey) in your `init.el` or `~/.wakatime.cfg` file.
+5. Enter your [api key](https://wakatime.com//api-key) in your `init.el` or `~/.wakatime.cfg` file.
 
 6. Use Emacs with wakatime-mode turned on and your time will be tracked for you automatically.
 
@@ -34,11 +32,9 @@ Enable WakaTime for the current buffer by invoking `M-x wakatime-mode`.  If you 
 
 ## Configuration
 
-Set variable `wakatime-api-key` to your [API key](https://wakatime.com/#apikey).
+Set variable `wakatime-api-key` to your [API key](https://wakatime.com/api-key).
 
-Point `wakatime-cli-path` to the absolute path of [wakatime-cli](https://pypi.python.org/pypi/wakatime).
-
-Optionally, point `wakatime-python-bin` to the absolute path of python on your system. Defaults to `python` which only works if python is in your PATH.
+Point `wakatime-cli-path` to the absolute path of [wakatime-cli](https://github.com/wakatime/wakatime-cli/releases).
 
 
 ## Troubleshooting


### PR DESCRIPTION
Fixes #58.

When this is merged, you will need to replace the old Python wakatime client with the new Go [wakatime-cli](https://github.com/wakatime/wakatime-cli/releases) on your machine running Emacs.