### PR TITLE
Address linting errors and restore support for Emacs <28

### DIFF
--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Gabor Torok <gabor@20y.hu>
 ;; Maintainer: Alan Hamlett <alan@wakatime.com>
-;; Website: https://wakatime.com
+;; Homepage: https://wakatime.com
 ;; Keywords: calendar, comm
 ;; Version: 1.0.2
 ;; Package-Requires: ((emacs "24.3") (s "1.13"))

--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -64,10 +64,11 @@
 
 
 (defun wakatime-debug (msg)
-  "Write a string to the *messages* buffer."
+  "Write MSG, a string, to the *messages* buffer."
   (message "%s" msg))
 
 (defun wakatime-init ()
+  "Initialize WakaTime and set up the CLI path."
   (unless wakatime-init-started
     (setq wakatime-init-started t)
     (when (s-blank? wakatime-cli-path)
@@ -98,7 +99,7 @@
     (setq wakatime-noprompt nil)))
 
 (defun wakatime-find-binary (program)
-  "Find the full path to an executable program."
+  "Find the full path to the WakaTime executable named PROGRAM."
   (cond
     ((file-exists-p (format "/usr/local/bin/%s" program))
       (format "/usr/local/bin/%s" program))
@@ -152,7 +153,8 @@ Set SAVEP to non-nil for write action."
     (if (s-blank? wakatime-api-key) "" (format " --key %s" wakatime-api-key))))
 
 (defun wakatime-call (savep)
-  "Call WakaTime command."
+  "Call WakaTime command.
+If SAVEP, indicate that the heartbeat is triggered by saving."
   (let*
     (
       (command (wakatime-client-command savep))
@@ -218,7 +220,8 @@ Set SAVEP to non-nil for write action."
   (remove-hook 'first-change-hook 'wakatime-ping t))
 
 (defun wakatime-turn-on (defer)
-  "Turn on WakaTime."
+  "Turn on WakaTime.
+If DEFER, actually turn on a second later."
   (if defer
     (run-at-time "1 sec" nil 'wakatime-turn-on nil)
     (let ()

--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -7,6 +7,7 @@
 ;; Website: https://wakatime.com
 ;; Keywords: calendar, comm
 ;; Version: 1.0.2
+;; Package-Requires: ((emacs "24.3") (s "1.13"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -32,6 +33,8 @@
 ;; from <https://github.com/wakatime/wakatime-cli/releases>.
 
 ;;; Code:
+
+(require 's)
 
 (defconst wakatime-version "1.0.2")
 (defconst wakatime-user-agent "emacs-wakatime")
@@ -65,18 +68,13 @@ the wakatime subprocess occurs."
   "Write a string to the *messages* buffer."
   (message "%s" msg))
 
-(defun s-blank (string)
-  "Return true if the string is empty or nil. Expects string."
-  (or (null string)
-    (zerop (length string))))
-
 (defun wakatime-init ()
   (unless wakatime-init-started
     (setq wakatime-init-started t)
-    (when (s-blank wakatime-cli-path)
+    (when (s-blank? wakatime-cli-path)
       (customize-set-variable 'wakatime-cli-path
 	(wakatime-find-binary "wakatime-cli")))
-    (when (s-blank wakatime-cli-path)
+    (when (s-blank? wakatime-cli-path)
       (wakatime-prompt-cli-path))
     (setq wakatime-init-finished t)))
 
@@ -120,25 +118,25 @@ the wakatime subprocess occurs."
       "~/.wakatime/wakatime-cli")
     ;; For windows 10+ fix to get wakatime-cli.exe
     ((file-exists-p (concat
-		(string-replace "\\" "/" (concat
+		(s-replace "\\" "/" (concat
 		(substitute-env-vars "$HOMEDRIVE")
 		(substitute-env-vars "$HOMEPATH")))
 		(format "/.wakatime/%s" program)))
-      (concat (string-replace "\\" "/" (concat
+      (concat (s-replace "\\" "/" (concat
 		(substitute-env-vars "$HOMEDRIVE")
 		(substitute-env-vars "$HOMEPATH")))
 		(format "/.wakatime/%s" program)))
     ;; For windows 10+ fix to get wakatime-cli-amd64.exe
     ((file-exists-p (concat
-		(string-replace "\\" "/" (concat
+		(s-replace "\\" "/" (concat
 		(substitute-env-vars "$HOMEDRIVE")
 		(substitute-env-vars "$HOMEPATH")))
 		"/.wakatime/wakatime-cli-windows-amd64.exe"))
-      (concat (string-replace "\\" "/" (concat
+      (concat (s-replace "\\" "/" (concat
 		(substitute-env-vars "$HOMEDRIVE")
 		(substitute-env-vars "$HOMEPATH")))
 		"/.wakatime/wakatime-cli-windows-amd64.exe"))
-    ((not (s-blank (executable-find "wakatime")))
+    ((not (s-blank? (executable-find "wakatime")))
       (executable-find "wakatime"))
     (t program)))
 
@@ -146,13 +144,13 @@ the wakatime subprocess occurs."
   "Return client command executable and arguments.
    Set SAVEP to non-nil for write action."
   (format "%s--entity %s --plugin \"%s/%s\" --time %.2f%s%s"
-    (if (s-blank wakatime-cli-path) "wakatime-cli " (format "%s " wakatime-cli-path))
+    (if (s-blank? wakatime-cli-path) "wakatime-cli " (format "%s " wakatime-cli-path))
     (shell-quote-argument (or file (buffer-file-name (current-buffer))))
     wakatime-user-agent
     wakatime-version
     (float-time)
     (if savep " --write" "")
-    (if (s-blank wakatime-api-key) "" (format " --key %s" wakatime-api-key))))
+    (if (s-blank? wakatime-api-key) "" (format " --key %s" wakatime-api-key))))
 
 (defun wakatime-call (savep)
   "Call WakaTime command."

--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -43,7 +43,7 @@
 (defvar wakatime-init-finished nil)
 
 (defgroup wakatime nil
-  "Customizations for WakaTime"
+  "Customizations for WakaTime."
   :group 'convenience
   :prefix "wakatime-")
 
@@ -58,8 +58,7 @@
   :group 'wakatime)
 
 (defcustom wakatime-disable-on-error nil
-  "Turn off wakatime-mode and wakatime-global-mode when errors in
-the wakatime subprocess occurs."
+  "Turn off WakaTime modes (both local and global) if the subprocess throws errors."
   :type 'boolean
   :group 'wakatime)
 
@@ -142,7 +141,7 @@ the wakatime subprocess occurs."
 
 (defun wakatime-client-command (savep &optional file)
   "Return client command executable and arguments.
-   Set SAVEP to non-nil for write action."
+Set SAVEP to non-nil for write action."
   (format "%s--entity %s --plugin \"%s/%s\" --time %.2f%s%s"
     (if (s-blank? wakatime-cli-path) "wakatime-cli " (format "%s " wakatime-cli-path))
     (shell-quote-argument (or file (buffer-file-name (current-buffer))))
@@ -181,7 +180,7 @@ the wakatime subprocess occurs."
                  (wakatime-mode -1)
                  (global-wakatime-mode -1))
                (cond
-                 ((= exit-status 103) (error "WakaTime Error (%s) Config file parse error. Check your ~/.wakatime.cfg file." exit-status))
+                 ((= exit-status 103) (error "WakaTime Error (%s) Config file parse error. Please check your ~/.wakatime.cfg file" exit-status))
                  ((= exit-status 104) (error "WakaTime Error (%s) Invalid API Key. Set your api key with: (custom-set-variables '(wakatime-api-key \"XXXX\"))" exit-status))
                  ((= exit-status 105) (error "WakaTime Error (%s) Unknown wakatime-cli error. Please check your ~/.wakatime/wakatime.log file and open a new issue at https://github.com/wakatime/wakatime-mode" exit-status))
                  ((= exit-status 106) (error "WakaTime Error (%s) Malformed heartbeat error. Please check your ~/.wakatime/wakatime.log file and open a new issue at https://github.com/wakatime/wakatime-mode" exit-status))

--- a/wakatime-mode.el
+++ b/wakatime-mode.el
@@ -1,4 +1,4 @@
-;;; wakatime-mode.el --- Automatic time tracking extension for WakaTime
+;;; wakatime-mode.el --- Automatic time tracking extension for WakaTime  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013  Gabor Torok <gabor@20y.hu>
 


### PR DESCRIPTION
![20240410T015614+0900](https://github.com/wakatime/wakatime-mode/assets/11722318/587b71ca-28ee-491b-917e-2b4af8db24fd)

*The errors in question*

Each commit in this PR fixes a class of issues. This PR also turns on `lexical-binding`. Ths issues are:

- 7d9054e1657fc27d6652ccd4fc7f28fa8a218d87 string-replace was added in Emacs 28, so up until now this package only worked on Emacs 28 or above. This could be fixed by:

  - depending on compat.el (new feature polyfills for old Emacs versions)
  - declaring Emacs 28 as a requirement
  - or using s-replace from s.el.

  I chose to depend on s.el because (a) it's on MELPA as well, (b) this package was already copying s-blank? inline (as `s-blank`, with the wrong package prefix), and (c) there is no need to drop Emacs pre-28 here.

  I replaced the `s-blank` function previously defined by this package with `s-blank?` from s.el, and `string-replace` with `s-replace`.

- c3ecb78408fcf346fa00e72fa973a045bce47ca3 Package should have a Homepage or URL header. Previously this package was using a nonstandard "Website" header.

- 8bd143ea208eb9ad0bf8885a58fb0c18f27af037 2b25d092fa39b538467e54b3d7af201d43e660b6 Docstrings should:

  - include all arguments
  - have a first line that is a complete sentence less than 80 characters long
  - not have indentation for normal paragraphs (they would make it into the docstring, not be trimmed like in Python, and end up looking weird in `*Help*` pages)

  Moreover, there is a strong nudge to add docstrings to all functions and variables. There was just one function without a docstring, so I wrote one for it.

The parentheses and indentation style should also be updated to be more conventional for Emacs Lisp, to make it less painful to edit without introducing lots of style noise. That is not in scope of this PR though, to make this PR easier to review.