### PR TITLE
docs: Clean up outdated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,24 @@
 
 ## Installation
 
-1. Install wakatime-mode for Emacs using [MELPA](https://melpa.org/#/wakatime-mode) (Doom users see [these instructions][doom install] instead).
+1. Configure `wakatime-mode` in your `init.el` file using `use-package` (this automatically installs it from [MELPA](https://melpa.org/#/wakatime-mode)):
 
-2. Download [wakatime-cli](https://github.com/wakatime/wakatime-cli/releases) to `~/.wakatime/` or somewhere in your `$PATH`. (Or `brew install wakatime-cli` on Mac)
+   ```elisp
+   (use-package wakatime-mode
+     :ensure t
+     :config
+     (global-wakatime-mode 1))
+   ```
 
-3. Add `(global-wakatime-mode)` to your `init.el` file, then restart Emacs.
+2. Download [`wakatime-cli`](https://github.com/wakatime/wakatime-cli/releases) to `~/.wakatime/` or somewhere in your `$PATH`. (Or [`brew install wakatime-cli`](https://formulae.brew.sh/formula/wakatime-cli) on Mac)
 
-4. You will see a prompt asking for the path to wakatime-cli. Run `which wakatime-cli` and enter that path into the emacs prompt, then press `enter`.
+3. Restart Emacs. You will see a prompt asking for the path to `wakatime-cli`. Run `which wakatime-cli` and enter that path into the emacs prompt, then press `enter`.
 
-5. Enter your [api key](https://wakatime.com//api-key) in your `init.el` or `~/.wakatime.cfg` file ([config file format](https://github.com/wakatime/wakatime-cli/blob/develop/USAGE.md#ini-config-file)).
+4. Enter your [api key](https://wakatime.com//api-key) in your `init.el` or `~/.wakatime.cfg` file ([config file format](https://github.com/wakatime/wakatime-cli/blob/develop/USAGE.md#ini-config-file)).
 
-6. Use Emacs with wakatime-mode turned on and your time will be tracked for you automatically.
+5. Use Emacs with wakatime-mode turned on and your time will be tracked for you automatically.
 
-7. Visit http://wakatime.com to see your logged time.
-
-### Installation for Spacemacs
-
-See [Installing WakaTime with Spacemacs](https://develop.spacemacs.org/layers/+web-services/wakatime/README.html).
+6. Visit http://wakatime.com to see your logged time.
 
 ## Screen Shots
 
@@ -34,7 +35,7 @@ Enable WakaTime for the current buffer by invoking `M-x wakatime-mode`. If you w
 
 Set variable `wakatime-api-key` to your [API key](https://wakatime.com/api-key).
 
-Point `wakatime-cli-path` to the absolute path of [wakatime-cli](https://github.com/wakatime/wakatime-cli/releases).
+Point `wakatime-cli-path` to the absolute path of [`wakatime-cli`](https://github.com/wakatime/wakatime-cli/releases).
 
 ## Troubleshooting
 
@@ -43,5 +44,3 @@ To be sure heartbeats are getting sent, turn on debug mode by adding this line t
     debug = true
 
 Then run `tail -f ~/.wakatime/wakatime.log` and make sure you see a 201 response code from the [WakaTime API](https://wakatime.com/api).
-
-[doom install]: https://medium.com/@el.gamerph/how-to-install-wakatime-in-doom-emacs-e5c582e15261


### PR DESCRIPTION
This PR cleans up the README by removing outdated installation references.

### Changes
- **Doom Emacs**: Removed the installation note and link. The guide relies on the deprecated Python `wakatime-cli` rather than the current Go implementation.
- **Spacemacs**: Removed the section since the linked page is no longer available.

### Note
FYI, the official Emacs setup guide at https://wakatime.com/emacs is also outdated and still references the Python CLI. It might be worth updating that page to reflect the Go version.